### PR TITLE
fix: serve correct handler for route by requestPath

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -64,18 +64,8 @@ const getPath = basePath => {
   return path.endsWith("/") ? path.replace(/\/$/, "") : path;
 };
 
-const deleteRoute = (app, path) => {
-  for (route in app._router.stack) {
-    if (
-      app._router.stack[route].path === path ||
-      app._router.stack[route].path === path.replace(/\/$/, "")
-    ) {
-      delete app._router.stack[route];
-    }
-  }
-
-  app._router.stack = app._router.stack.filter(Boolean);
-};
+// handlers for all routes
+const routeHandlers = {};
 
 const createServer = async ({
   basePath,
@@ -88,7 +78,7 @@ const createServer = async ({
   watch = true,
   webpackConfig: customConfig
 }) => {
-  var firstRun = true;
+  let firstRun = true;
   const app = express();
   app.use(bodyParser.raw());
   app.use(bodyParser.text({ type: "*/*" }));
@@ -102,9 +92,16 @@ const createServer = async ({
         const { source } = modules.find(build =>
           build.identifier.includes(lambda.file)
         );
-        deleteRoute(app, requestPath);
-        app.all(requestPath, createHandler(source, lambda.file));
+
+        // set new handler for requestPath
+        routeHandlers[requestPath] = createHandler(source, lambda.file);
+
         if (firstRun) {
+          // create route that calls handler by requestPath
+          app.all(requestPath, (req, res) =>
+            routeHandlers[requestPath](req, res)
+          );
+
           console.log(
             `${prefix} Serving Function ${chalk.green(
               `http://localhost:${port}${requestPath}`


### PR DESCRIPTION
Sometimes, when editing a file, `serve` will log that a new built has been made, but still serve the original build when making a request, like no changes have been made.

Other times it will serve the built before the latest change, so you would always be a build behind.

It's difficult to reproduce, but changing several files long enough will cause the error for me.

I tracked it down to the `deleteRoute` function:

https://github.com/iiroj/lambda-dev/blob/56cc345fb01139fec8696bf6d27f88ea5072ade9/lib/serve.js#L67-L78

and when adding a new route:

https://github.com/iiroj/lambda-dev/blob/56cc345fb01139fec8696bf6d27f88ea5072ade9/lib/serve.js#L106 

I think modifying `app._router.stack` manually is the issue. I don't think you can be sure that a route is deleted when editing an internal not documented object.

So when you run `app.all(requestPath, createHandler(source, lambda.file));` afterwards, the new route doesn't take effect all the time.

I've instead created an object that gets all handlers set on each build.
And then on `firstRun` I'm creating a handler that will dynamically call the correct handler from the object.

I believe that will solve it, and be a better solution as express could change how `app._router.stack` works each release.